### PR TITLE
Update citation and reference for NEON beetle data

### DIFF
--- a/data/neon_beetles/README.md
+++ b/data/neon_beetles/README.md
@@ -1,6 +1,6 @@
 # NEON Beetle Part Masks 🪲
 
-This dataset provides hand-labeled part segmentation annotations for Imageomics' [NEON Beetles Dataset](https://huggingface.co/datasets/imageomics/2018-NEON-beetles).
+This dataset provides hand-labeled part segmentation annotations for the [2018 NEON Ethanol-preserved Ground Beetles Dataset](https://huggingface.co/datasets/imageomics/2018-NEON-beetles) (specifically [Revision 7b3731d](https://huggingface.co/datasets/imageomics/2018-NEON-beetles/tree/7b3731daca1f91931f8086d6782ab9150ab8ce26)).
 
 It includes 180 carefully labeled images with five part segmentation classes: Head, Pronotum, Elytra, Antenna, and Legs.
 
@@ -9,26 +9,25 @@ A sample code for downloading the images and visualizing the masks can be found 
 
 
 ## Citation
-If you use this dataset in your research, please cite both [our work](../../README.md#-citation) and the original dataset as follows:
+If you use this dataset in your research, please cite both [our work](../../README.md#-citation) and the [original dataset](https://huggingface.co/datasets/imageomics/2018-NEON-beetles/tree/7b3731daca1f91931f8086d6782ab9150ab8ce26) as follows:
 
 ```bibtex
 @misc{Fluck2018_NEON_Beetle,
   author = {Isadora E. Fluck and Benjamin Baiser and Riley Wolcheski and Isha Chinniah and Sydne Record},
-  title = {2018 {NEON} Ethanol-preserved Ground Beetles},
-  year = {2024},
+  title = {2018 {NEON} Ethanol-preserved Ground Beetles (Revision 7b3731d)},
+  year = {2025},
   url = {https://huggingface.co/datasets/imageomics/2018-NEON-beetles},
-  doi = {<doi once generated>},
+  doi = {10.57967/hf/5252},
   publisher = {Hugging Face}
 }
 
 
-@software{Ramirez_2018_NEON_Ethanol-preserved_2024,
-author = {Ramirez, Michelle and Nepovinnykh, Ekaterina and Campolongo, Elizabeth G.},
-license = {MIT},
-month = aug,
-title = {{2018 NEON Ethanol-preserved Ground Beetles Processing}},
-url = {https://github.com/Imageomics/2018-NEON-beetles-processing},
-version = {1.0.0},
-year = {2024}
+@software{Ramirez_2018_NEON_Ethanol-preserved_2025,
+        author = {Ramirez, Michelle and Nepovinnykh, Ekaterina and Ali, Sarwan and Campolongo, Elizabeth G.},
+        license = {MIT},
+        title = {{2018 NEON Ethanol-preserved Ground Beetles Processing}},
+        url = {https://github.com/Imageomics/2018-NEON-beetles-processing},
+        version = {2.0.0},
+        year = {2025}
 }
 ```


### PR DESCRIPTION
Includes link to dataset Revision used and the associated processing repository (the source dataset was the [`separate_segmented_train_test_splits_80_20/`](https://huggingface.co/datasets/imageomics/2018-NEON-beetles/tree/7b3731daca1f91931f8086d6782ab9150ab8ce26/Separate_segmented_train_test_splits_80_20) subset of the [2018 NEON Ethanol-preserved Ground Beetles](https://huggingface.co/datasets/imageomics/2018-NEON-beetles). The citation for this subset was updated to include the DOI and specify the revision, as well as the appropriate citation for the processing repository (as it has been clarified).